### PR TITLE
Add mutineer leader role and recruitment action

### DIFF
--- a/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
+++ b/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
@@ -1,0 +1,42 @@
+using Content.Client.Eui;
+using Content.Shared._RMC14.Marines.Mutiny;
+using JetBrains.Annotations;
+using Robust.Client.Graphics;
+
+namespace Content.Client._RMC14.Marines.Mutiny;
+
+[UsedImplicitly]
+public sealed class MutineerInviteEui : BaseEui
+{
+    private readonly MutineerInviteWindow _window;
+
+    public MutineerInviteEui()
+    {
+        _window = new MutineerInviteWindow();
+
+        _window.DenyButton.OnPressed += _ =>
+        {
+            SendMessage(new MutineerInviteChoiceMessage(MutineerInviteUiButton.Deny));
+            _window.Close();
+        };
+
+        _window.OnClose += () => SendMessage(new MutineerInviteChoiceMessage(MutineerInviteUiButton.Deny));
+
+        _window.AcceptButton.OnPressed += _ =>
+        {
+            SendMessage(new MutineerInviteChoiceMessage(MutineerInviteUiButton.Accept));
+            _window.Close();
+        };
+    }
+
+    public override void Opened()
+    {
+        IoCManager.Resolve<IClyde>().RequestWindowAttention();
+        _window.OpenCentered();
+    }
+
+    public override void Closed()
+    {
+        _window.Close();
+    }
+}

--- a/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteWindow.cs
+++ b/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteWindow.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Localization;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+
+namespace Content.Client._RMC14.Marines.Mutiny;
+
+public sealed class MutineerInviteWindow : DefaultWindow
+{
+    public readonly Button DenyButton;
+    public readonly Button AcceptButton;
+
+    public MutineerInviteWindow()
+    {
+        Title = Loc.GetString("mutineer-invite-title");
+
+        AcceptButton = new Button
+        {
+            Text = Loc.GetString("mutineer-invite-accept")
+        };
+
+        DenyButton = new Button
+        {
+            Text = Loc.GetString("mutineer-invite-deny")
+        };
+
+        Contents.AddChild(new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Children =
+            {
+                new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Vertical,
+                    Children =
+                    {
+                        new Label
+                        {
+                            Text = Loc.GetString("mutineer-invite-text")
+                        },
+                        new BoxContainer
+                        {
+                            Orientation = LayoutOrientation.Horizontal,
+                            Align = AlignMode.Center,
+                            Children =
+                            {
+                                AcceptButton,
+                                new Control
+                                {
+                                    MinSize = new Vector2(20, 0)
+                                },
+                                DenyButton
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteWindow.cs
+++ b/Content.Client/_RMC14/Marines/Mutiny/MutineerInviteWindow.cs
@@ -9,8 +9,8 @@ namespace Content.Client._RMC14.Marines.Mutiny;
 
 public sealed class MutineerInviteWindow : DefaultWindow
 {
-    public readonly Button DenyButton;
-    public readonly Button AcceptButton;
+    public Button DenyButton { get; }
+    public Button AcceptButton { get; }
 
     public MutineerInviteWindow()
     {
@@ -26,37 +26,30 @@ public sealed class MutineerInviteWindow : DefaultWindow
             Text = Loc.GetString("mutineer-invite-deny")
         };
 
-        Contents.AddChild(new BoxContainer
+        var layout = new BoxContainer
         {
-            Orientation = LayoutOrientation.Vertical,
-            Children =
-            {
-                new BoxContainer
-                {
-                    Orientation = LayoutOrientation.Vertical,
-                    Children =
-                    {
-                        new Label
-                        {
-                            Text = Loc.GetString("mutineer-invite-text")
-                        },
-                        new BoxContainer
-                        {
-                            Orientation = LayoutOrientation.Horizontal,
-                            Align = AlignMode.Center,
-                            Children =
-                            {
-                                AcceptButton,
-                                new Control
-                                {
-                                    MinSize = new Vector2(20, 0)
-                                },
-                                DenyButton
-                            }
-                        }
-                    }
-                }
-            }
+            Orientation = LayoutOrientation.Vertical
+        };
+
+        layout.AddChild(new Label
+        {
+            Text = Loc.GetString("mutineer-invite-text")
         });
+
+        var buttonRow = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            Align = AlignMode.Center
+        };
+
+        buttonRow.AddChild(AcceptButton);
+        buttonRow.AddChild(new Control
+        {
+            MinSize = new Vector2(20, 0)
+        });
+        buttonRow.AddChild(DenyButton);
+
+        layout.AddChild(buttonRow);
+        Contents.AddChild(layout);
     }
 }

--- a/Content.Server/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
@@ -1,4 +1,5 @@
 using Content.Server.EUI;
+using Content.Shared.Eui;
 using Content.Shared._RMC14.Marines.Mutiny;
 
 namespace Content.Server._RMC14.Marines.Mutiny;

--- a/Content.Server/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutineerInviteEui.cs
@@ -1,0 +1,31 @@
+using Content.Server.EUI;
+using Content.Shared._RMC14.Marines.Mutiny;
+
+namespace Content.Server._RMC14.Marines.Mutiny;
+
+public sealed class MutineerInviteEui : BaseEui
+{
+    private readonly EntityUid _target;
+    private readonly MutinySystem _mutiny;
+
+    public MutineerInviteEui(EntityUid target, MutinySystem mutiny)
+    {
+        _target = target;
+        _mutiny = mutiny;
+    }
+
+    public override void HandleMessage(EuiMessageBase msg)
+    {
+        base.HandleMessage(msg);
+
+        if (msg is not MutineerInviteChoiceMessage choice ||
+            choice.Button != MutineerInviteUiButton.Accept)
+        {
+            Close();
+            return;
+        }
+
+        _mutiny.MakeMutineer(_target);
+        Close();
+    }
+}

--- a/Content.Server/_RMC14/Marines/Mutiny/MutinyCommand.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutinyCommand.cs
@@ -84,4 +84,34 @@ public sealed class MutinyCommand : ToolshedCommand
     {
         return marines.Select(marine => RemoveMutineer(ctx, marine));
     }
+
+    [CommandImplementation("makemutineerleader"), AdminCommand(AdminFlags.Fun)]
+    public EntityUid MakeMutineerLeader([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine)
+    {
+        EnsureComp<MutineerLeaderComponent>(marine);
+        return marine;
+    }
+
+    [CommandImplementation("makemutineerleader"), AdminCommand(AdminFlags.Fun)]
+    public IEnumerable<EntityUid> MakeMutineerLeader([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines)
+    {
+        return marines.Select(marine => MakeMutineerLeader(ctx, marine));
+    }
+
+    [CommandImplementation("removemutineerleader"), AdminCommand(AdminFlags.Fun)]
+    public EntityUid RemoveMutineerLeader([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine)
+    {
+        RemComp<MutineerLeaderComponent>(marine);
+        return marine;
+    }
+
+    [CommandImplementation("removemutineerleader"), AdminCommand(AdminFlags.Fun)]
+    public IEnumerable<EntityUid> RemoveMutineerLeader([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines)
+    {
+        return marines.Select(marine => RemoveMutineerLeader(ctx, marine));
+    }
 }

--- a/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Administration;
 using Content.Shared.Database;
 using Content.Shared.Mind.Components;
 using Content.Shared.Verbs;
+using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -154,13 +155,13 @@ public sealed class MutinySystem : SharedMutinySystem
         if (args.Handled)
             return;
 
-        if (args.Target == null || HasComp<MutineerComponent>(args.Target) || !HasComp<MarineComponent>(args.Target))
+        if (!args.Target.IsValid() || HasComp<MutineerComponent>(args.Target) || !HasComp<MarineComponent>(args.Target))
             return;
 
-        if (!TryComp<ActorComponent>(args.Target.Value, out var actor))
+        if (!TryComp<ActorComponent>(args.Target, out var actor))
             return;
 
         args.Handled = true;
-        _euis.OpenEui(new MutineerInviteEui(args.Target.Value, this), actor.PlayerSession);
+        _euis.OpenEui(new MutineerInviteEui(args.Target, this), actor.PlayerSession);
     }
 }

--- a/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
+using Content.Server.EUI;
+using Content.Server.Actions;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Mutiny;
 using Content.Shared.Administration;
@@ -15,12 +17,19 @@ public sealed class MutinySystem : SharedMutinySystem
 {
     [Dependency] private readonly IAdminManager _adminManager = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly EuiManager _euis = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddMakeMutineerVerb);
+        SubscribeLocalEvent<MutineerLeaderComponent, ComponentStartup>(OnLeaderStartup);
+        SubscribeLocalEvent<MutineerLeaderComponent, ComponentShutdown>(OnLeaderShutdown);
+        SubscribeLocalEvent<MutineerLeaderComponent, ComponentAdd>(OnLeaderAdded);
+        SubscribeLocalEvent<MutineerLeaderComponent, ComponentRemove>(OnLeaderRemoved);
+        SubscribeLocalEvent<MutineerLeaderComponent, MutineerRecruitActionEvent>(OnRecruitAction);
     }
 
     private void AddMakeMutineerVerb(GetVerbsEvent<Verb> args)
@@ -39,29 +48,44 @@ public sealed class MutinySystem : SharedMutinySystem
         if (!HasComp<MindContainerComponent>(args.Target) || !TryComp<ActorComponent>(args.Target, out var targetActor))
             return;
 
-        if (TryComp<MarineComponent>(args.Target, out var marine))
-        {
-            // Must be a marine.
-            if (!HasComp<MutineerComponent>(args.Target))
-            {
-                // Must not already be a mutineer.
+        if (!TryComp<MarineComponent>(args.Target, out var marine))
+            return;
 
-                Verb mutineer = new()
-                {
-                    Text = "Make mutineer",
-                    Category = VerbCategory.Antag,
-                    Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
-                        "hudmutineer"),
-                    Act = () =>
-                    {
-                        EnsureComp<MutineerComponent>(args.Target);
-                    },
-                    Impact = LogImpact.High,
-                    Message = "Make mutineer",
-                };
-                args.Verbs.Add(mutineer);
-            }
+        if (!HasComp<MutineerComponent>(args.Target))
+        {
+            Verb mutineer = new()
+            {
+                Text = "Make mutineer",
+                Category = VerbCategory.Antag,
+                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
+                    "hudmutineer"),
+                Act = () => { EnsureComp<MutineerComponent>(args.Target); },
+                Impact = LogImpact.High,
+                Message = "Make mutineer",
+            };
+            args.Verbs.Add(mutineer);
         }
+
+        if (!HasComp<MutineerLeaderComponent>(args.Target))
+        {
+            Verb leader = new()
+            {
+                Text = "Make mutineer leader",
+                Category = VerbCategory.Antag,
+                // Use the regular mutineer icon for the admin verb until a unique leader icon exists
+                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
+                    "hudmutineer"),
+                Act = () => { EnsureComp<MutineerLeaderComponent>(args.Target); },
+                Impact = LogImpact.High,
+                Message = "Make mutineer leader",
+            };
+            args.Verbs.Add(leader);
+        }
+    }
+
+    public void MakeMutineer(EntityUid uid)
+    {
+        EnsureComp<MutineerComponent>(uid);
     }
 
     protected override void MutineerAdded(Entity<MutineerComponent> ent, ref ComponentAdd args)
@@ -90,5 +114,53 @@ public sealed class MutinySystem : SharedMutinySystem
         }
 
         Dirty(ent);
+    }
+
+    private void OnLeaderStartup(Entity<MutineerLeaderComponent> ent, ref ComponentStartup args)
+    {
+        EnsureComp<MutineerComponent>(ent.Owner);
+        _actions.AddAction(ent, ref ent.Comp.RecruitActionEntity, ent.Comp.RecruitAction);
+        Dirty(ent);
+    }
+
+    private void OnLeaderShutdown(Entity<MutineerLeaderComponent> ent, ref ComponentShutdown args)
+    {
+        _actions.RemoveAction(ent.Owner, ent.Comp.RecruitActionEntity);
+    }
+
+    private void OnLeaderAdded(Entity<MutineerLeaderComponent> ent, ref ComponentAdd args)
+    {
+        if (TryComp<ActorComponent>(ent, out var actor))
+        {
+            _chatManager.DispatchServerMessage(actor.PlayerSession, Loc.GetString("mutineer-leader-status-added"));
+            _chatManager.SendAdminAnnouncement($"Player {actor.PlayerSession.Name} was made a mutineer leader.");
+        }
+        Dirty(ent);
+    }
+
+    private void OnLeaderRemoved(Entity<MutineerLeaderComponent> ent, ref ComponentRemove args)
+    {
+        if (TryComp<ActorComponent>(ent, out var actor))
+        {
+            _chatManager.DispatchServerMessage(actor.PlayerSession, Loc.GetString("mutineer-leader-status-removed"));
+            _chatManager.SendAdminAnnouncement($"Player {actor.PlayerSession.Name} is no longer a mutineer leader.");
+        }
+        _actions.RemoveAction(ent.Owner, ent.Comp.RecruitActionEntity);
+        Dirty(ent);
+    }
+
+    private void OnRecruitAction(Entity<MutineerLeaderComponent> ent, ref MutineerRecruitActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (args.Target == null || HasComp<MutineerComponent>(args.Target) || !HasComp<MarineComponent>(args.Target))
+            return;
+
+        if (!TryComp<ActorComponent>(args.Target.Value, out var actor))
+            return;
+
+        args.Handled = true;
+        _euis.OpenEui(new MutineerInviteEui(args.Target.Value, this), actor.PlayerSession);
     }
 }

--- a/Content.Shared/_RMC14/Marines/Mutiny/MutineerInviteEuiMessage.cs
+++ b/Content.Shared/_RMC14/Marines/Mutiny/MutineerInviteEuiMessage.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Eui;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Marines.Mutiny;
+
+[Serializable, NetSerializable]
+public enum MutineerInviteUiButton
+{
+    Deny,
+    Accept,
+}
+
+[Serializable, NetSerializable]
+public sealed class MutineerInviteChoiceMessage : EuiMessageBase
+{
+    public readonly MutineerInviteUiButton Button;
+
+    public MutineerInviteChoiceMessage(MutineerInviteUiButton button)
+    {
+        Button = button;
+    }
+}

--- a/Content.Shared/_RMC14/Marines/Mutiny/MutineerLeaderComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Mutiny/MutineerLeaderComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Actions;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._RMC14.Marines.Mutiny;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class MutineerLeaderComponent : Component
+{
+    [DataField("icon"), AutoNetworkedField]
+    // Reuse the standard mutineer icon until dedicated leader artwork is available
+    public SpriteSpecifier Icon = new SpriteSpecifier.Rsi(new ResPath("_RMC14/Interface/cm_job_icons.rsi"), "hudmutineer");
+
+    [DataField("recruitAction"), AutoNetworkedField]
+    public EntProtoId RecruitAction = "ActionMutineerRecruit";
+
+    [DataField("recruitActionEntity"), AutoNetworkedField]
+    public EntityUid? RecruitActionEntity;
+}

--- a/Content.Shared/_RMC14/Marines/Mutiny/MutineerRecruitActionEvent.cs
+++ b/Content.Shared/_RMC14/Marines/Mutiny/MutineerRecruitActionEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Marines.Mutiny;
+
+public sealed partial class MutineerRecruitActionEvent : EntityTargetActionEvent
+{
+    [DataField]
+    public float Range = 1.5f;
+}

--- a/Content.Shared/_RMC14/Marines/Mutiny/SharedMutinySystem.cs
+++ b/Content.Shared/_RMC14/Marines/Mutiny/SharedMutinySystem.cs
@@ -7,6 +7,7 @@ public abstract class SharedMutinySystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<MutineerComponent, GetMarineIconEvent>(OnGetMarineIcon, after: [typeof(SquadSystem)]);
+        SubscribeLocalEvent<MutineerLeaderComponent, GetMarineIconEvent>(OnGetLeaderIcon, after: [typeof(SquadSystem)]);
 
         SubscribeLocalEvent<MutineerComponent, ComponentAdd>(MutineerAdded);
         SubscribeLocalEvent<MutineerComponent, ComponentRemove>(MutineerRemoved);
@@ -15,6 +16,11 @@ public abstract class SharedMutinySystem : EntitySystem
     private void OnGetMarineIcon(Entity<MutineerComponent> mutineer, ref GetMarineIconEvent args)
     {
         args.Icon = mutineer.Comp.Icon;
+    }
+
+    private void OnGetLeaderIcon(Entity<MutineerLeaderComponent> leader, ref GetMarineIconEvent args)
+    {
+        args.Icon = leader.Comp.Icon;
     }
 
     protected abstract void MutineerAdded(Entity<MutineerComponent> ent, ref ComponentAdd args);

--- a/Resources/Locale/en-US/_RMC14/mutiny/mutiny.ftl
+++ b/Resources/Locale/en-US/_RMC14/mutiny/mutiny.ftl
@@ -3,6 +3,15 @@ command-description-mutiny-ismutineer = Returns Yes if the entity is a mutineer,
 command-description-mutiny-list = Lists all current mutineers.
 command-description-mutiny-makemutineer = Makes an entity a mutineer. Note that the icon is only rendered on marines.
 command-description-mutiny-removemutineer = Makes an entity no longer a mutineer.
+command-description-mutiny-makemutineerleader = Makes an entity a mutineer leader.
+command-description-mutiny-removemutineerleader = Makes an entity no longer a mutineer leader.
 
-mutineer-status-added = You have been made a mutineer by a Game Admin. You may now participate in the ongoing mutiny.
+mutineer-status-added = You have been made a mutineer. You may now participate in the ongoing mutiny.
 mutineer-status-removed = You are no longer a mutineer and should not participate in an mutiny activity anymore.
+mutineer-leader-status-added = You have been made the leader of the mutiny.
+mutineer-leader-status-removed = You are no longer the leader of the mutiny.
+
+mutineer-invite-title = Mutiny Invitation
+mutineer-invite-text = You are being asked to join the mutiny.
+mutineer-invite-accept = Join
+mutineer-invite-deny = Decline

--- a/Resources/Prototypes/_RMC14/Actions/mutiny_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/mutiny_actions.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: ActionMutineerRecruit
+  parent: ActionMarineBase
+  name: Recruit mutineer
+  description: Ask a marine to join the mutiny.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Interface/cm_job_icons.rsi
+      state: hudmutineer
+    useDelay: 2
+  - type: TargetAction
+    range: 1.5
+  - type: EntityTargetAction
+    event: !type:MutineerRecruitActionEvent


### PR DESCRIPTION
## Summary
- Add mutineer leader component with consent-based recruitment ability
- Reuse existing mutineer HUD icon instead of adding new sprite files
- Initialize invite window buttons outside child collection to avoid compile errors

## Testing
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `dotnet build Content.Server/Content.Server.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9e8e2c288323857d3209effa3fd3