### PR TITLE
Prevent MPs and command from joining mutiny

### DIFF
--- a/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutinySystem.cs
@@ -4,6 +4,7 @@ using Content.Server.EUI;
 using Content.Server.Actions;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Mutiny;
+using Content.Shared._RMC14.Synth;
 using Content.Shared.Administration;
 using Content.Shared.Database;
 using Content.Shared.Mind.Components;
@@ -156,6 +157,12 @@ public sealed class MutinySystem : SharedMutinySystem
             return;
 
         if (!args.Target.IsValid() || HasComp<MutineerComponent>(args.Target) || !HasComp<MarineComponent>(args.Target))
+            return;
+
+        if (!TryComp<MindContainerComponent>(args.Target, out var mind) || !mind.HasMind)
+            return;
+
+        if (HasComp<MutinyImmuneComponent>(args.Target) || HasComp<SynthComponent>(args.Target))
             return;
 
         if (!TryComp<ActorComponent>(args.Target, out var actor))

--- a/Content.Shared/_RMC14/Marines/Mutiny/MutinyImmuneComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Mutiny/MutinyImmuneComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Marines.Mutiny;
+
+/// <summary>
+///     Marks a character as ineligible for mutiny recruitment.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MutinyImmuneComponent : Component
+{
+}
+

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/senior_enlisted_advisor.yml
@@ -85,6 +85,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_medical
     - type: RMCTrackable
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearSeniorEnlistedAdvisor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
@@ -97,6 +97,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_command
     - type: RMCTrackable
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearCommandingOfficer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
@@ -60,6 +60,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_command
     - type: RMCTrackable
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearExecutiveOfficer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
@@ -62,6 +62,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_command
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearStaffOfficer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
@@ -59,6 +59,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: cmp
     - type: RMCTrackable
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearChiefMP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_police.yml
@@ -44,6 +44,7 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: mp
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearMilitaryPolice

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
@@ -52,6 +52,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: warden
     - type: RMCTrackable
+    - type: MutinyImmune
 
 - type: startingGear
   id: CMGearMilitaryWarden


### PR DESCRIPTION
## Summary
- add MutinyImmune component for jobs immune to mutiny recruitment
- tag MP and command roles with MutinyImmune
- block MutinyImmune and synth entities from mutiny invitations

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*