### PR TITLE
Expand Xeno PvE AI with role-driven behaviors

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -2,6 +2,27 @@
 - type: htnCompound
   id: CMXenoCompound
   branches:
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: IsHarasser
+    tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoHarassCompound
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: IsFlanker
+    tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoFlankCompound
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: IsDefender
+    tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoDefenderCompound
+  - tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoRangedCombatCompound
   - tasks:
     - !type:HTNCompoundTask
       task: CMXenoMeleeCombatCompound
@@ -19,7 +40,91 @@
       operator: !type:UtilityOperator
         proto: NearbyMeleeTargets
     - !type:HTNCompoundTask
-      task: MeleeAttackTargetCompound
+      task: CMXenoAttackTargetCompound
+
+# Flanking attack that jukes before striking.
+- type: htnCompound
+  id: CMXenoAttackTargetCompound
+  branches:
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: Target
+    tasks:
+    - !type:HTNPrimitiveTask
+      operator: !type:MoveToOperator
+        shutdownState: PlanFinished
+        pathfindInPlanning: true
+        removeKeyOnFinish: false
+        targetKey: TargetCoordinates
+        pathfindKey: TargetPathfind
+        rangeKey: MeleeRange
+        stopOnLineOfSight: true
+    - !type:HTNPrimitiveTask
+      operator: !type:JukeOperator
+        jukeType: AdjacentTile
+    - !type:HTNPrimitiveTask
+      operator: !type:SetRandomFloatOperator
+        targetKey: TelegraphTime
+        minAmount: 0.2
+        maxAmount: 0.5
+    - !type:HTNPrimitiveTask
+      operator: !type:WaitOperator
+        key: TelegraphTime
+      preconditions:
+      - !type:KeyExistsPrecondition
+        key: TelegraphTime
+    - !type:HTNPrimitiveTask
+      operator: !type:MeleeOperator
+        targetKey: Target
+      preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
+      - !type:TargetInRangePrecondition
+        targetKey: Target
+        rangeKey: MeleeRange
+      services:
+      - !type:UtilityService
+        id: MeleeService
+        proto: NearbyMeleeTargets
+        key: Target
+
+# Ranged harassment using innate projectiles if available.
+- type: htnCompound
+  id: CMXenoRangedCombatCompound
+  branches:
+  - tasks:
+    - !type:HTNCompoundTask
+      task: InnateRangedCombatCompound
+
+# Ranged harassment priority for harassing roles.
+- type: htnCompound
+  id: CMXenoHarassCompound
+  branches:
+  - tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoRangedCombatCompound
+    - !type:HTNCompoundTask
+      task: CMXenoMeleeCombatCompound
+
+# Aggressive flanking and pressure for melee specialists.
+- type: htnCompound
+  id: CMXenoFlankCompound
+  branches:
+  - tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoAttackTargetCompound
+    - !type:HTNCompoundTask
+      task: IdleCompound
+
+# Defensive stance that guards territory.
+- type: htnCompound
+  id: CMXenoDefenderCompound
+  branches:
+  - tasks:
+    - !type:HTNCompoundTask
+      task: CMXenoMeleeCombatCompound
+    - !type:HTNCompoundTask
+      task: IdleCompound
 
 - type: emote
   id: CMXenoDeathGasp
@@ -452,10 +557,19 @@
   id: CMXenoAI
   parent: CMXenoBase
   abstract: true
-#  components:
-#  - type: HTN # TODO RMC14 needs to not target nested marines
-#    rootTask:
-#      task: CMXenoCompound
+  components:
+  - type: HTN
+    rootTask:
+      task: CMXenoCompound
+    blackboard:
+      NavClimb: !type:Bool
+        true
+      NavInteract: !type:Bool
+        true
+      NavPry: !type:Bool
+        true
+      NavSmash: !type:Bool
+        true
 
 - type: entity
   id: CMXenoDeveloped

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -2,6 +2,7 @@
   abstract: true
   parent:
   - CMXenoDeveloped
+  - CMXenoAI
   - CMXenoTail
   - CMXenoFlammable
   - RMCXenoSpeechSounds
@@ -13,6 +14,15 @@
   components:
   - type: GhostRole
     name: cm-job-name-xeno-hivelord
+  - type: HTN
+    rootTask:
+      task: CMXenoCompound
+    blackboard:
+      NavClimb: !type:Bool true
+      NavInteract: !type:Bool true
+      NavPry: !type:Bool true
+      NavSmash: !type:Bool true
+      IsDefender: !type:Bool true
   - type: MobState
     allowedStates:
     - Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent:
   - CMXenoDeveloped
+  - CMXenoAI
   - CMXenoTail
   - CMXenoFlammable
   - RMCXenoSpeechSounds
@@ -15,6 +16,15 @@
     - RMCGuideRoleSentinel
   - type: GhostRole
     name: cm-job-name-xeno-sentinel
+  - type: HTN
+    rootTask:
+      task: CMXenoCompound
+    blackboard:
+      NavClimb: !type:Bool true
+      NavInteract: !type:Bool true
+      NavPry: !type:Bool true
+      NavSmash: !type:Bool true
+      IsHarasser: !type:Bool true
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Sentinel/sentinel.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent:
   - CMXenoDeveloped
+  - CMXenoAI
   - CMXenoTail
   - CMXenoFlammable
   - RMCXenoSpeechSounds
@@ -15,6 +16,15 @@
     - RMCGuideRoleWarrior
   - type: GhostRole
     name: cm-job-name-xeno-warrior
+  - type: HTN
+    rootTask:
+      task: CMXenoCompound
+    blackboard:
+      NavClimb: !type:Bool true
+      NavInteract: !type:Bool true
+      NavPry: !type:Bool true
+      NavSmash: !type:Bool true
+      IsFlanker: !type:Bool true
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Warrior/warrior.rsi
   - type: MobState


### PR DESCRIPTION
## Summary
- add role-specific branches for harasser, flanker, and defender Xeno AI
- telegraph melee attacks with a random delay before striking
- wire up sentinel, warrior, and hivelord to new AI roles

## Testing
- ❌ `dotnet test Content.Tests/Content.Tests.csproj -c Release --no-build` (command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68b05480e71c8323b5c17e1b6d7ad496