### PR TITLE
Add flipchart structure for briefings

### DIFF
--- a/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
+++ b/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Flipchart;
+using Content.Shared.Interaction;
 using Content.Shared.Paper;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
@@ -30,10 +31,11 @@ public sealed class FlipchartSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract || ent.Comp.Pages.Count == 0)
             return;
 
+        var user = args.User;
         args.Verbs.Add(new Verb
         {
             Text = Loc.GetString("flipchart-verb-next-page"),
-            Act = () => NextPage(ent, args.User)
+            Act = () => NextPage(ent, user)
         });
     }
 

--- a/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
+++ b/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
@@ -1,0 +1,56 @@
+using System;
+using Content.Shared._RMC14.Flipchart;
+using Content.Shared.Paper;
+using Content.Shared.Verbs;
+using Robust.Shared.Localization;
+
+namespace Content.Server._RMC14.Flipchart;
+
+public sealed class FlipchartSystem : EntitySystem
+{
+    [Dependency] private readonly PaperSystem _paper = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FlipchartComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<FlipchartComponent, GetVerbsEvent<Verb>>(OnVerb);
+    }
+
+    private void OnInit(Entity<FlipchartComponent> ent, ref ComponentInit args)
+    {
+        if (ent.Comp.Pages.Count == 0)
+            ent.Comp.Pages.Add(string.Empty);
+        ent.Comp.CurrentPage = Math.Clamp(ent.Comp.CurrentPage, 0, ent.Comp.Pages.Count - 1);
+
+        if (TryComp<PaperComponent>(ent, out var paper))
+            _paper.SetContent((ent.Owner, paper), ent.Comp.Pages[ent.Comp.CurrentPage]);
+    }
+
+    private void OnVerb(Entity<FlipchartComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        args.Verbs.Add(new Verb
+        {
+            Text = Loc.GetString("flipchart-verb-next-page"),
+            Act = () => NextPage(ent)
+        });
+    }
+
+    private void NextPage(Entity<FlipchartComponent> ent)
+    {
+        if (!TryComp<PaperComponent>(ent, out var paper))
+            return;
+
+        if (ent.Comp.CurrentPage >= 0 && ent.Comp.CurrentPage < ent.Comp.Pages.Count)
+            ent.Comp.Pages[ent.Comp.CurrentPage] = paper.Content;
+
+        ent.Comp.CurrentPage++;
+        if (ent.Comp.CurrentPage >= ent.Comp.Pages.Count)
+            ent.Comp.Pages.Add(string.Empty);
+
+        _paper.SetContent((ent.Owner, paper), ent.Comp.Pages[ent.Comp.CurrentPage]);
+        Dirty(ent);
+    }
+}

--- a/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
+++ b/Content.Server/_RMC14/Flipchart/FlipchartSystem.cs
@@ -1,7 +1,8 @@
-using System;
 using Content.Shared._RMC14.Flipchart;
 using Content.Shared.Paper;
+using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared.UserInterface;
 using Robust.Shared.Localization;
 
 namespace Content.Server._RMC14.Flipchart;
@@ -9,48 +10,87 @@ namespace Content.Server._RMC14.Flipchart;
 public sealed class FlipchartSystem : EntitySystem
 {
     [Dependency] private readonly PaperSystem _paper = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<FlipchartComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<FlipchartComponent, ActivatableUIOpenAttemptEvent>(OnOpenAttempt);
+        SubscribeLocalEvent<FlipchartComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<FlipchartComponent, GetVerbsEvent<Verb>>(OnVerb);
     }
 
     private void OnInit(Entity<FlipchartComponent> ent, ref ComponentInit args)
     {
-        if (ent.Comp.Pages.Count == 0)
-            ent.Comp.Pages.Add(string.Empty);
-        ent.Comp.CurrentPage = Math.Clamp(ent.Comp.CurrentPage, 0, ent.Comp.Pages.Count - 1);
-
-        if (TryComp<PaperComponent>(ent, out var paper))
-            _paper.SetContent((ent.Owner, paper), ent.Comp.Pages[ent.Comp.CurrentPage]);
+        ent.Comp.CurrentPage = 0;
     }
 
     private void OnVerb(Entity<FlipchartComponent> ent, ref GetVerbsEvent<Verb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
+        if (!args.CanAccess || !args.CanInteract || ent.Comp.Pages.Count == 0)
             return;
 
         args.Verbs.Add(new Verb
         {
             Text = Loc.GetString("flipchart-verb-next-page"),
-            Act = () => NextPage(ent)
+            Act = () => NextPage(ent, args.User)
         });
     }
 
-    private void NextPage(Entity<FlipchartComponent> ent)
+    private void NextPage(Entity<FlipchartComponent> ent, EntityUid user)
     {
         if (!TryComp<PaperComponent>(ent, out var paper))
             return;
 
-        if (ent.Comp.CurrentPage >= 0 && ent.Comp.CurrentPage < ent.Comp.Pages.Count)
-            ent.Comp.Pages[ent.Comp.CurrentPage] = paper.Content;
+        if (ent.Comp.Pages.Count == 0)
+        {
+            _popup.PopupClient(Loc.GetString("flipchart-popup-empty"), user, ent);
+            return;
+        }
+
+        ent.Comp.Pages[ent.Comp.CurrentPage] = paper.Content;
+
+        if (ent.Comp.CurrentPage >= ent.Comp.Pages.Count - 1)
+        {
+            _popup.PopupClient(Loc.GetString("flipchart-popup-no-pages"), user, ent);
+            return;
+        }
 
         ent.Comp.CurrentPage++;
-        if (ent.Comp.CurrentPage >= ent.Comp.Pages.Count)
-            ent.Comp.Pages.Add(string.Empty);
 
         _paper.SetContent((ent.Owner, paper), ent.Comp.Pages[ent.Comp.CurrentPage]);
         Dirty(ent);
+    }
+
+    private void OnOpenAttempt(Entity<FlipchartComponent> ent, ref ActivatableUIOpenAttemptEvent args)
+    {
+        if (ent.Comp.Pages.Count != 0)
+            return;
+
+        _popup.PopupClient(Loc.GetString("flipchart-popup-empty"), args.User, ent);
+        args.Cancel();
+    }
+
+    private void OnInteractUsing(Entity<FlipchartComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<PaperComponent>(args.Used, out var paper))
+            return;
+
+        if (!TryComp<PaperComponent>(ent, out var boardPaper))
+            boardPaper = AddComp<PaperComponent>(ent.Owner);
+
+        // insert after current page
+        var index = ent.Comp.CurrentPage + 1;
+        ent.Comp.Pages.Insert(index, paper.Content);
+        ent.Comp.CurrentPage = index;
+        _paper.SetContent((ent.Owner, boardPaper), paper.Content);
+        Dirty(ent);
+
+        QueueDel(args.Used);
+        _popup.PopupClient(Loc.GetString("flipchart-popup-added"), args.User, ent);
+        args.Handled = true;
     }
 }

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
+using Content.Shared._RMC14.Flipchart;
 using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
 using static Content.Shared.Paper.PaperComponent;
@@ -89,7 +90,7 @@ public sealed class PaperSystem : EntitySystem
 
     private void OnExamined(Entity<PaperComponent> entity, ref ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange)
+        if (!args.IsInDetailsRange && !HasComp<Content.Shared._RMC14.Flipchart.FlipchartComponent>(entity))
             return;
 
         using (args.PushGroup(nameof(PaperComponent)))

--- a/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
+++ b/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Flipchart;
+
+/// <summary>
+/// Stores multiple pages of text for a flipchart.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FlipchartComponent : Component
+{
+    /// <summary>
+    /// The text content of each page.
+    /// </summary>
+    [DataField]
+    public List<string> Pages = new() { "" };
+
+    /// <summary>
+    /// Index of the currently displayed page.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int CurrentPage;
+}

--- a/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
+++ b/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._RMC14.Flipchart;
 /// <summary>
 /// Stores multiple pages of text for a flipchart.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class FlipchartComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
+++ b/Content.Shared/_RMC14/Flipchart/FlipchartComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class FlipchartComponent : Component
     /// The text content of each page.
     /// </summary>
     [DataField]
-    public List<string> Pages = new() { "" };
+    public List<string> Pages = new();
 
     /// <summary>
     /// Index of the currently displayed page.

--- a/Resources/Locale/en-US/_RMC14/flipchart/flipchart.ftl
+++ b/Resources/Locale/en-US/_RMC14/flipchart/flipchart.ftl
@@ -1,1 +1,4 @@
 flipchart-verb-next-page = Next page
+flipchart-popup-empty = The flipchart is empty.
+flipchart-popup-no-pages = There is no more paper.
+flipchart-popup-added = You attach the paper to the flipchart.

--- a/Resources/Locale/en-US/_RMC14/flipchart/flipchart.ftl
+++ b/Resources/Locale/en-US/_RMC14/flipchart/flipchart.ftl
@@ -1,0 +1,1 @@
+flipchart-verb-next-page = Next page

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
@@ -1,0 +1,46 @@
+- type: entity
+  parent: BaseStructure
+  id: RMCFlipchart
+  name: flipchart
+  description: A standing board with large paper sheets for briefings and debriefs.
+  components:
+  - type: Sprite
+    sprite: Structures/Wallmounts/noticeboard.rsi
+    layers:
+      - state: noticeboard
+  - type: Paper
+  - type: PaperLabelType
+  - type: ActivatableUI
+    key: enum.PaperUiKey.Key
+    requiresComplex: false
+  - type: UserInterface
+    interfaces:
+      enum.PaperUiKey.Key:
+        type: PaperBoundUserInterface
+  - type: InteractionOutline
+  - type: Clickable
+  - type: Tag
+    tags:
+    - Wooden
+  - type: Damageable
+    damageModifierSet: Wood
+    damageContainer: StructuralInorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 30
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 1
+            max: 2
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Construction
+    graph: NoticeBoard
+    node: noticeBoard

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
@@ -8,7 +8,6 @@
     sprite: Structures/Wallmounts/noticeboard.rsi
     layers:
       - state: noticeboard
-  - type: Paper
   - type: PaperLabelType
   - type: Flipchart
   - type: ActivatableUI

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/flipchart.yml
@@ -10,6 +10,7 @@
       - state: noticeboard
   - type: Paper
   - type: PaperLabelType
+  - type: Flipchart
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
     requiresComplex: false

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Furniture/flipchart.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Furniture/flipchart.yml
@@ -1,0 +1,26 @@
+- type: constructionGraph
+  id: RMCFlipchart
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DestroyEntity {}
+      edges:
+        - to: flipchart
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: WoodPlank
+              amount: 3
+              doAfter: 2
+    - node: flipchart
+      entity: RMCFlipchart
+      edges:
+        - to: start
+          completed:
+            - !type:GivePrototype
+              prototype: MaterialWoodPlank
+              amount: 3
+          steps:
+            - tool: Prying
+              doAfter: 3

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/furniture.yml
@@ -198,3 +198,18 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+
+- type: construction
+  parent: RMC
+  id: RMCFlipchart
+  name: flipchart
+  description: A standing board with large paper sheets for briefings and debriefs.
+  graph: RMCFlipchart
+  startNode: start
+  targetNode: flipchart
+  category: construction-category-cm-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked


### PR DESCRIPTION
## Summary
- add flipchart structure that can be written on for briefings and debriefs
- allow construction of flipchart via new recipe and graph

## Testing
- `dotnet test Content.Tests/Content.Tests.csproj -c Release` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, unable to access repositories)*