### PR TITLE
Add manual fueling controls for dropships

### DIFF
--- a/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
@@ -1,10 +1,12 @@
-﻿using Content.Client.Message;
+﻿using System;
+using Content.Client.Message;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared.Doors.Components;
 using Content.Shared.Shuttles.Systems;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Client._RMC14.Dropship;
 
@@ -19,6 +21,8 @@ public sealed class DropshipNavigationBui : BoundUserInterface
 
     private readonly Dictionary<DropshipButton, string> _destinations = new();
     private NetEntity? _selected;
+    private bool _manualFuelingBlocked;
+    private DropshipManualFuelingData? _manualFueling;
 
     public DropshipNavigationBui(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
@@ -81,6 +85,12 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             ResetDestinationButtons();
         };
 
+        _window.FuelButton.Button.OnPressed += _ =>
+        {
+            _window.FuelButton.Button.Disabled = true;
+            SendPredictedMessage(new DropshipNavigationFuelMsg());
+        };
+
         _window.LockdownButton.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.None));
         _window.LockdownButtonAft.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.Aft));
         _window.LockdownButtonPort.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.Port));
@@ -99,6 +109,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         if (_window == null)
             return;
 
+        SetManualFueling(destinations.ManualFueling);
         SetFlightHeader("Flight Controls");
 
         _window.DestinationsContainer.Visible = true;
@@ -153,6 +164,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         if (_window == null)
             return;
 
+        SetManualFueling(null);
         _window.DestinationsContainer.Visible = false;
         _window.ProgressBarContainer.Visible = true;
         _window.LaunchButton.Visible = false;
@@ -207,6 +219,69 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         _window.ProgressBar.SetAsRatio(1 - startEndTime.ProgressAt(_timing.CurTime));
     }
 
+    private void SetManualFueling(DropshipManualFuelingData? data)
+    {
+        if (_window == null)
+            return;
+
+        _manualFueling = data;
+        _manualFuelingBlocked = false;
+
+        _window.FuelStatus.Visible = false;
+        _window.FuelStatus.SetMarkup(string.Empty);
+        _window.FuelButton.Visible = false;
+        _window.FuelButton.Button.Disabled = false;
+
+        if (data == null)
+            return;
+
+        var autoRemaining = MathF.Max(0f, data.Value.AutoFuelingSecondsRemaining);
+        if (data.Value.ManualFuelingComplete || autoRemaining <= 0f)
+            return;
+
+        _manualFuelingBlocked = true;
+        _window.FuelStatus.Visible = true;
+        _window.FuelButton.Visible = true;
+
+        if (data.Value.ManualFuelingTime is { } fuelingTime)
+        {
+            var secondsLeft = MathF.Ceiling((float) (fuelingTime.End - _timing.CurTime).TotalSeconds);
+            if (secondsLeft < 0)
+                secondsLeft = 0;
+
+            _window.FuelStatus.SetMarkup(Loc.GetString("rmc-dropship-manual-fueling-progress", ("seconds", (int) secondsLeft)));
+            _window.FuelButton.Text = Loc.GetString("rmc-dropship-manual-fueling-button-progress");
+            _window.FuelButton.Button.Disabled = true;
+        }
+        else
+        {
+            var minutesLeft = Math.Max(1, (int) MathF.Ceiling(autoRemaining / 60f));
+            _window.FuelStatus.SetMarkup(Loc.GetString("rmc-dropship-pre-flight-fueling", ("minutes", minutesLeft)));
+            _window.FuelButton.Text = Loc.GetString("rmc-dropship-manual-fueling-button");
+            _window.FuelButton.Button.Disabled = false;
+        }
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (_window == null)
+            return;
+
+        if (_manualFueling is not { ManualFuelingTime: { } fuelingTime })
+            return;
+
+        var secondsLeft = MathF.Ceiling((float) (fuelingTime.End - _timing.CurTime).TotalSeconds);
+        if (secondsLeft < 0)
+            secondsLeft = 0;
+
+        _window.FuelStatus.SetMarkup(Loc.GetString("rmc-dropship-manual-fueling-progress", ("seconds", (int) secondsLeft)));
+
+        if (secondsLeft <= 0)
+            _window.FuelButton.Button.Disabled = true;
+    }
+
     private void SetFlightHeader(string label)
     {
         _window?.Header.SetMarkup($"[color=#0BDC49][font size=16][bold]{label}[/bold][/font][/color]");
@@ -222,7 +297,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         if (_window == null)
             return;
 
-        _window.LaunchButton.Button.Disabled = disabled;
+        _window.LaunchButton.Button.Disabled = disabled || _manualFuelingBlocked;
     }
 
     private void SetCancelDisabled(bool disabled)
@@ -230,7 +305,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         if (_window == null)
             return;
 
-        _window.CancelButton.Button.Disabled = disabled;
+        _window.CancelButton.Button.Disabled = disabled || _manualFuelingBlocked;
     }
 
     private void SetLockDownDisabled(bool disabled)

--- a/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
@@ -14,6 +14,10 @@
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5">
                 <RichTextLabel Name="Header" Access="Public" />
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Align="End">
+                    <controls:DropshipButton Name="FuelButton" Access="Public"
+                                             Margin="1" BackgroundColor="#004E25"
+                                             BorderColor="#02E74E" BorderThickness="1"
+                                             Text="Manual Fuel" Visible="False" />
                     <controls:DropshipButton Name="CancelButton" Access="Public"
                                              Margin="1" BackgroundColor="#004E25"
                                              BorderColor="#02E74E" BorderThickness="1"
@@ -25,6 +29,7 @@
                 </BoxContainer>
             </BoxContainer>
             <cc:HSeparator Color="#02E74E" />
+            <RichTextLabel Name="FuelStatus" Access="Public" Margin="5" Visible="False" />
             <BoxContainer Name="DestinationsContainer" Access="Public" Orientation="Vertical"
                           Margin="5" />
             <BoxContainer Name="ProgressBarContainer" Access="Public" Orientation="Vertical"

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using Content.Server._RMC14.Marines;
 using Content.Server.Doors.Systems;
 using Content.Server.GameTicking;
@@ -240,6 +241,49 @@ public sealed class DropshipSystem : SharedDropshipSystem
         OnRefreshUI((grid, dropship), ref args);
     }
 
+    protected override void OnDropshipNavigationFuelMsg(Entity<DropshipNavigationComputerComponent> ent, ref DropshipNavigationFuelMsg args)
+    {
+        base.OnDropshipNavigationFuelMsg(ent, ref args);
+
+        var user = args.Actor;
+        if (user == null)
+            return;
+
+        if (_transform.GetGrid(ent.Owner) is not { } grid ||
+            !TryComp(grid, out DropshipComponent? dropship))
+        {
+            return;
+        }
+
+        var roundDuration = _gameTicker.RoundDuration();
+        if (roundDuration >= _dropshipInitialDelay)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-dropship-manual-fueling-not-needed"), ent.Owner, user.Value);
+            return;
+        }
+
+        if (dropship.ManualFuelingComplete)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-dropship-manual-fueling-already-complete"), ent.Owner, user.Value);
+            return;
+        }
+
+        var time = _timing.CurTime;
+        if (dropship.ManualFuelingEndTime is { } finish && finish > time)
+        {
+            var secondsLeft = Math.Max(1, (int) Math.Ceiling((finish - time).TotalSeconds));
+            _popup.PopupEntity(Loc.GetString("rmc-dropship-manual-fueling-already-in-progress", ("seconds", secondsLeft)), ent.Owner, user.Value);
+            return;
+        }
+
+        dropship.ManualFuelingEndTime = time + dropship.ManualFuelingDuration;
+        Dirty(grid, dropship);
+
+        _popup.PopupEntity(Loc.GetString("rmc-dropship-manual-fueling-start"), ent.Owner, user.Value);
+        RefreshUI(ent);
+        RefreshUI();
+    }
+
     public override bool FlyTo(Entity<DropshipNavigationComputerComponent> computer, EntityUid destination, EntityUid? user, bool hijack = false, float? startupTime = null, float? hyperspaceTime = null, bool offset = false)
     {
         base.FlyTo(computer, destination, user, hijack, startupTime, hyperspaceTime);
@@ -408,6 +452,24 @@ public sealed class DropshipSystem : SharedDropshipSystem
             !ftl.Running ||
             ftl.State == FTLState.Available)
         {
+            DropshipManualFuelingData? manualFueling = null;
+            if (TryComp(grid, out DropshipComponent? dropship) && !dropship.ManualFuelingComplete)
+            {
+                var roundDuration = _gameTicker.RoundDuration();
+                var autoRemaining = (float) (_dropshipInitialDelay - roundDuration).TotalSeconds;
+                if (autoRemaining > 0f)
+                {
+                    StartEndTime? manualFuelingTime = null;
+                    if (dropship.ManualFuelingEndTime is { } finish && finish > _timing.CurTime)
+                    {
+                        var start = finish - dropship.ManualFuelingDuration;
+                        manualFuelingTime = new StartEndTime(start, finish);
+                    }
+
+                    manualFueling = new DropshipManualFuelingData(dropship.ManualFuelingComplete, manualFuelingTime, autoRemaining);
+                }
+            }
+
             NetEntity? flyBy = null;
             var destinations = new List<Destination>();
             var query = EntityQueryEnumerator<DropshipDestinationComponent>();
@@ -429,7 +491,7 @@ public sealed class DropshipSystem : SharedDropshipSystem
                 destinations.Add(destination);
             }
 
-            var state = new DropshipNavigationDestinationsBuiState(flyBy, destinations, doorLockStatus);
+            var state = new DropshipNavigationDestinationsBuiState(flyBy, destinations, doorLockStatus, manualFueling);
             _ui.SetUiState(computer.Owner, DropshipNavigationUiKey.Key, state);
             return;
         }
@@ -578,7 +640,35 @@ public sealed class DropshipSystem : SharedDropshipSystem
     {
         base.Update(frameTime);
 
-        var time = _timing.CurTime;
+        var curTime = _timing.CurTime;
+        var roundDuration = _gameTicker.RoundDuration();
+
+        var refreshFuel = false;
+        var manualQuery = EntityQueryEnumerator<DropshipComponent>();
+        while (manualQuery.MoveNext(out var uid, out var dropship))
+        {
+            if (!dropship.ManualFuelingComplete && roundDuration >= _dropshipInitialDelay)
+            {
+                dropship.ManualFuelingComplete = true;
+                dropship.ManualFuelingEndTime = null;
+                Dirty(uid, dropship);
+                refreshFuel = true;
+                continue;
+            }
+
+            if (dropship.ManualFuelingEndTime is not { } finish || finish > curTime)
+                continue;
+
+            dropship.ManualFuelingEndTime = null;
+            dropship.ManualFuelingComplete = true;
+            Dirty(uid, dropship);
+            refreshFuel = true;
+        }
+
+        if (refreshFuel)
+            RefreshUI();
+
+        var time = curTime;
 
         var dropships = EntityQueryEnumerator<DropshipComponent, FTLComponent>();
         while (dropships.MoveNext(out var uid, out var dropship, out var ftl))

--- a/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
@@ -47,6 +47,15 @@ public sealed partial class DropshipComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan? RechargeTime;
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan ManualFuelingDuration = TimeSpan.FromSeconds(120);
+
+    [DataField, AutoNetworkedField]
+    public bool ManualFuelingComplete;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? ManualFuelingEndTime;
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan? HijackLandAt;
 

--- a/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
@@ -6,11 +6,12 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._RMC14.Dropship;
 
 [Serializable, NetSerializable]
-public sealed class DropshipNavigationDestinationsBuiState(NetEntity? flyBy, List<Destination> destinations, Dictionary<DoorLocation, bool> doorLockStatus) : BoundUserInterfaceState
+public sealed class DropshipNavigationDestinationsBuiState(NetEntity? flyBy, List<Destination> destinations, Dictionary<DoorLocation, bool> doorLockStatus, DropshipManualFuelingData? manualFueling) : BoundUserInterfaceState
 {
     public readonly NetEntity? FlyBy = flyBy;
     public readonly List<Destination> Destinations = destinations;
     public readonly Dictionary<DoorLocation, bool> DoorLockStatus = doorLockStatus;
+    public readonly DropshipManualFuelingData? ManualFueling = manualFueling;
 }
 
 [Serializable, NetSerializable]
@@ -41,6 +42,11 @@ public sealed class DropshipLockdownMsg(DoorLocation doorLocation) : BoundUserIn
 }
 
 [Serializable, NetSerializable]
+public sealed class DropshipNavigationFuelMsg : BoundUserInterfaceMessage
+{
+}
+
+[Serializable, NetSerializable]
 public enum DropshipNavigationUiKey
 {
     Key
@@ -48,3 +54,6 @@ public enum DropshipNavigationUiKey
 
 [Serializable, NetSerializable]
 public readonly record struct Destination(NetEntity Id, string Name, bool Occupied, bool Primary);
+
+[Serializable, NetSerializable]
+public sealed record DropshipManualFuelingData(bool ManualFuelingComplete, StartEndTime? ManualFuelingTime, float AutoFuelingSecondsRemaining);

--- a/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Shuttles.Systems;
 using Content.Shared.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -73,6 +74,7 @@ public abstract class SharedDropshipSystem : EntitySystem
             {
                 subs.Event<DropshipNavigationLaunchMsg>(OnDropshipNavigationLaunchMsg);
                 subs.Event<DropshipNavigationCancelMsg>(OnDropshipNavigationCancelMsg);
+                subs.Event<DropshipNavigationFuelMsg>(OnDropshipNavigationFuelMsg);
             });
 
         Subs.BuiEvents<DropshipNavigationComputerComponent>(DropshipHijackerUiKey.Key,
@@ -379,6 +381,10 @@ public abstract class SharedDropshipSystem : EntitySystem
     {
     }
 
+    protected virtual void OnDropshipNavigationFuelMsg(Entity<DropshipNavigationComputerComponent> computer, ref DropshipNavigationFuelMsg args)
+    {
+    }
+
     protected virtual bool IsShuttle(EntityUid dropship)
     {
         return false;
@@ -394,6 +400,9 @@ public abstract class SharedDropshipSystem : EntitySystem
         var roundDuration = _gameTicker.RoundDuration();
         if (roundDuration < _dropshipInitialDelay)
         {
+            if (ManualFuelingReady(computer))
+                return true;
+
             var minutesLeft = Math.Max(1, (int)(_dropshipInitialDelay - roundDuration).TotalMinutes);
             var msg = Loc.GetString("rmc-dropship-pre-flight-fueling", ("minutes", minutesLeft));
 
@@ -406,6 +415,26 @@ public abstract class SharedDropshipSystem : EntitySystem
         }
 
         return true;
+    }
+
+    private bool ManualFuelingReady(EntityUid computer)
+    {
+        if (!TryComp(computer, out TransformComponent? transform) ||
+            transform.ParentUid is not { Valid: true } parent)
+        {
+            return false;
+        }
+
+        if (!TryComp(parent, out DropshipComponent? dropship))
+            return false;
+
+        if (dropship.ManualFuelingComplete)
+            return true;
+
+        if (dropship.ManualFuelingEndTime is { } finish && _timing.CurTime >= finish)
+            return true;
+
+        return false;
     }
 
     protected bool TryDropshipHijackPopup(EntityUid computer, Entity<DropshipHijackerComponent?> user, bool predicted)

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -1,6 +1,13 @@
 ﻿rmc-dropship-pre-flight-fueling = The shuttle is still undergoing pre-flight fueling and cannot depart yet. Please wait another {$minutes} minutes before trying again.
 rmc-dropship-pre-hijack = This terminal won't be operational for another {$minutes} minutes.
 rmc-dropship-invalid-hijack = Lights flash from the terminal but you can't comprehend their meaning.
+rmc-dropship-manual-fueling-button = Manual Fuel
+rmc-dropship-manual-fueling-button-progress = Fueling...
+rmc-dropship-manual-fueling-progress = Manual fueling in progress. Ready in T-{$seconds}s.
+rmc-dropship-manual-fueling-start = You begin manually fueling the dropship.
+rmc-dropship-manual-fueling-not-needed = The dropship is already fully fueled.
+rmc-dropship-manual-fueling-already-complete = Manual fueling has already been completed.
+rmc-dropship-manual-fueling-already-in-progress = Manual fueling is already underway. Ready in T-{$seconds}s.
 
 rmc-dropship-weapons-title = Weapons Console
 


### PR DESCRIPTION
## Summary
- add manual fueling state to dropships so that refueling can be tracked server-side
- expose a manual fuel button in the navigation console UI with progress feedback
- localize new manual fueling messages

## Testing
- `dotnet build SpaceStation14.sln -c Release` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e933c7cea083239ed672e82826753c