### PR TITLE
Fix cassette custom track serialization

### DIFF
--- a/Content.Client/_RMC14/Cassette/CassetteSystem.cs
+++ b/Content.Client/_RMC14/Cassette/CassetteSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -24,6 +25,7 @@ public sealed class CassetteSystem : SharedCassetteSystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IFileDialogManager _dialogs = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
@@ -85,10 +87,13 @@ public sealed class CassetteSystem : SharedCassetteSystem
         }
     }
 
-    protected override EntityUid? PlayCustomTrack(Entity<CassettePlayerComponent> player, Entity<CassetteTapeComponent> tape)
+    protected override EntityUid? PlayCustomTrack(Entity<CassettePlayerComponent> player, Entity<CassetteTapeComponent> tape, int track)
     {
-        base.PlayCustomTrack(player, tape);
-        if (tape.Comp.CustomTrack is not AudioStream stream)
+        base.PlayCustomTrack(player, tape, track);
+        if (track < 0 || track >= tape.Comp.CustomTracks.Count)
+            return null;
+
+        if (tape.Comp.CustomTracks[track] is not AudioStream stream)
             return null;
 
         if (!_timing.IsFirstTimePredicted)
@@ -114,11 +119,14 @@ public sealed class CassetteSystem : SharedCassetteSystem
                 return;
 
             var audio = _audioManager.LoadAudioOggVorbis(file);
-            tape.Comp.CustomTrack = audio;
+            tape.Comp.CustomTracks.Add(audio);
 
             var name = $"/Audio/_RMC14/_CustomCassetteUploads/upload_{_names.Count}.ogg";
             _resourceCache.CacheResource(name, new AudioResource(audio));
             _names[audio] = name;
+
+            if (_net.IsClient && _net.IsConnected)
+                RaiseNetworkEvent(new CassetteCustomTrackCountEvent(EntityManager.GetNetEntity(tape.Owner), tape.Comp.CustomTracks.Count));
         }
         catch (Exception e)
         {

--- a/Content.Shared/_RMC14/Cassette/CassetteCustomTrackCountEvent.cs
+++ b/Content.Shared/_RMC14/Cassette/CassetteCustomTrackCountEvent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Cassette;
+
+[NetSerializable, Serializable]
+public sealed class CassetteCustomTrackCountEvent(NetEntity tape, int count) : EntityEventArgs
+{
+    public readonly NetEntity Tape = tape;
+
+    public readonly int Count = count;
+}

--- a/Content.Shared/_RMC14/Cassette/CassetteTapeComponent.cs
+++ b/Content.Shared/_RMC14/Cassette/CassetteTapeComponent.cs
@@ -14,5 +14,8 @@ public sealed partial class CassetteTapeComponent : Component
     public bool Custom;
 
     [DataField]
-    public object? CustomTrack;
+    public List<object> CustomTracks = new();
+
+    [DataField, AutoNetworkedField]
+    public int CustomTrackCount;
 }

--- a/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.CCVar;
+﻿using System;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
@@ -54,6 +55,26 @@ public abstract class SharedCassetteSystem : EntitySystem
         SubscribeLocalEvent<CassetteTapeComponent, ExaminedEvent>(OnTapeExamined);
         SubscribeLocalEvent<CassetteTapeComponent, UseInHandEvent>(OnPlayerUseInHand);
         SubscribeLocalEvent<CassetteTapeComponent, GetVerbsEvent<AlternativeVerb>>(OnTapeGetVerbsAlternative);
+
+        SubscribeNetworkEvent<CassetteCustomTrackCountEvent>(OnCustomTrackCount);
+    }
+
+    private void OnCustomTrackCount(CassetteCustomTrackCountEvent ev, EntitySessionEventArgs args)
+    {
+        if (!_net.IsServer || !_net.IsConnected)
+            return;
+
+        var tapeUid = GetEntity(ev.Tape);
+
+        if (!TryComp(tapeUid, out CassetteTapeComponent? tape))
+            return;
+
+        var newCount = Math.Max(tape.CustomTrackCount, ev.Count);
+        if (newCount == tape.CustomTrackCount)
+            return;
+
+        tape.CustomTrackCount = newCount;
+        Dirty(tapeUid, tape);
     }
 
     private void OnPlayerDetached(PlayerDetachedEvent ev)
@@ -164,15 +185,20 @@ public abstract class SharedCassetteSystem : EntitySystem
         StopAllAudio(player);
 
         tape ??= player.Comp.Tape;
-        if (tape < 0 || tape >= tapeComp.Songs.Count)
+        var totalSongs = GetTotalSongs(player);
+        if (totalSongs <= 0)
+            return;
+
+        if (tape < 0 || tape >= totalSongs)
             tape = 0;
 
-        if (tapeComp.Custom)
-        {
-            if (PlayCustomTrack(player, (tapeId.Value, tapeComp)) is { } custom)
-                player.Comp.CustomAudioStream = custom;
+        var customIndex = tape.Value - tapeComp.Songs.Count;
 
-            player.Comp.Tape = 0;
+        if (tapeComp.Custom && customIndex >= 0)
+        {
+            if (customIndex < tapeComp.CustomTracks.Count &&
+                PlayCustomTrack(player, (tapeId.Value, tapeComp), customIndex) is { } custom)
+                player.Comp.CustomAudioStream = custom;
         }
         else if (_net.IsServer)
         {
@@ -294,7 +320,11 @@ public abstract class SharedCassetteSystem : EntitySystem
         using (args.PushGroup(nameof(CassetteTapeComponent)))
         {
             if (ent.Comp.Custom)
-                args.PushMarkup(Loc.GetString("rmc-cassette-tape-custom"));
+            {
+                var customTracks = Math.Max(ent.Comp.CustomTrackCount, ent.Comp.CustomTracks.Count);
+                var total = ent.Comp.Songs.Count + customTracks;
+                args.PushMarkup(Loc.GetString("rmc-cassette-tape-custom", ("total", total)));
+            }
             else
                 args.PushMarkup(Loc.GetString("rmc-cassette-tape-examine", ("total", ent.Comp.Songs.Count)));
         }
@@ -353,14 +383,11 @@ public abstract class SharedCassetteSystem : EntitySystem
         if (!TryGetTape(player, out var tape))
             return 0;
 
-        var total = tape.Comp.Songs.Count;
-        if (tape is { Comp.CustomTrack: not null })
-            total++;
-
-        return total;
+        var customTracks = Math.Max(tape.Comp.CustomTrackCount, tape.Comp.CustomTracks.Count);
+        return tape.Comp.Songs.Count + customTracks;
     }
 
-    protected virtual EntityUid? PlayCustomTrack(Entity<CassettePlayerComponent> player, Entity<CassetteTapeComponent> tape)
+    protected virtual EntityUid? PlayCustomTrack(Entity<CassettePlayerComponent> player, Entity<CassetteTapeComponent> tape, int track)
     {
         return null;
     }

--- a/Resources/Locale/en-US/_RMC14/rmc-cassette.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-cassette.ftl
@@ -5,7 +5,7 @@ rmc-cassette-resume = Resuming {$current} of {$total}
 rmc-cassette-change = You change the song, {$current} of {$total}
 rmc-cassette-restart = You restart the song, {$current} of {$total}
 rmc-cassette-tape-examine = It has [color=lightblue]{$total}[/color] tracks.
-rmc-cassette-tape-custom = [color=cyan]Use it while in your hand to choose a custom track to play.[/color]
+rmc-cassette-tape-custom = [color=cyan]Use it while in your hand to add a custom track to play.[/color] It currently has [color=lightblue]{$total}[/color] tracks.
 rmc-cassette-tape-custom-choose = Choose a track
 rmc-cassette-player-examine-tape = It has a {$tape} inside.
 rmc-cassette-player-examine-none = It doesn't have a cassette inside.


### PR DESCRIPTION
## Summary
- send cassette custom track counts using NetEntity to avoid serialization errors
- convert custom track count handling to resolve NetEntity before updating cassette state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3117c5e0832383e691c1420e9666)